### PR TITLE
Update version check for 32-bit python on OSX Lion

### DIFF
--- a/rl/build.sh
+++ b/rl/build.sh
@@ -20,7 +20,8 @@ if [ `uname` == "Darwin" ]; then
   elif [[ $LATEST_SDK == /Developer/SDKs/MacOSX10.5.sdk ]]; then
     export CFLAGS='-isysroot '${LATEST_SDK}' -arch i386 -arch ppc -arch x86_64 -arch ppc64'
     export LDFLAGS='-syslibroot,'${LATEST_SDK}' -arch i386 -arch ppc -arch x86_64 -arch ppc64'
-  elif [[ $LATEST_SDK == /Developer/SDKs/MacOSX10.6.sdk ]]; then
+  elif [[ $LATEST_SDK == /Developer/SDKs/MacOSX10.6.sdk || $LATEST_SDK > /Developer/SDKs/MacOSX10.6.sdk ]]; then
+
     # Starting with 10.6 (Snow Leopard), only Intel architecture is supported
     export CFLAGS='-isysroot '${LATEST_SDK}' -arch i386 -arch x86_64'
     export LDFLAGS='-syslibroot,'${LATEST_SDK}' -arch i386 -arch x86_64'


### PR DESCRIPTION
_-i386 build missing on OSX Lion_

I run 32-bit python on Mac OSX 10.7 using the flag VERSIONER_PYTHON_PREFER_32_BIT. I had to update build.sh to fix the architectures.
