### PR TITLE
Fix build on OS X Lion with (some) developer tools installed

### DIFF
--- a/rl/build.sh
+++ b/rl/build.sh
@@ -4,7 +4,7 @@ set -e
 # If we are on Mac OS X, do a universal build
 if [ `uname` == "Darwin" ]; then
   # On older versions of Mac OS X, look for the latest SDK
-  if [ -d /Developer ]; then
+  if [ -d /Developer/SDKs ]; then
     LATEST_SDK=''
     for sdk_dir in /Developer/SDKs/*; do
       LATEST_SDK=$sdk_dir


### PR DESCRIPTION
If you have, e.g., Hardware IO Tools installed, there actually _is_ a `/Developer` folder in Lion. But, it does _not_ contain any SDK. Fixed `build.sh` to check for existence of an actual SDK, i.e. `/Developer/SDKs`.
