### PR TITLE
ensure readline.__doc__ is defined

### DIFF
--- a/readline.py
+++ b/readline.py
@@ -1,1 +1,2 @@
 from gnureadline import *
+from gnureadline import __doc__


### PR DESCRIPTION
some checks for libedit use `'libedit' in readline.__doc__`, which is None right now.
