### PR TITLE
Fix quiting isearch mode via ctl-c

### DIFF
--- a/Modules/3.x/readline.c
+++ b/Modules/3.x/readline.c
@@ -1151,6 +1151,12 @@ readline_until_enter_or_signal(const char *prompt, int *signal)
             PyEval_SaveThread();
 #endif
             if (s < 0) {
+
+#if defined(RL_READLINE_VERSION) && RL_READLINE_VERSION >= 0x0700
+ 	        rl_callback_sigcleanup();
+#else
+	        RL_UNSETSTATE(RL_STATE_ISEARCH);
+#endif
                 rl_free_line_state();
                 rl_cleanup_after_signal();
                 rl_callback_handler_remove();


### PR DESCRIPTION
This is port of / extension of the patches in https://bugs.python.org/issue24266

I am mostly opening this for easy discussion else where, I do not expect this to be merged.

The first commit is a direct merging of the two patches in the upstream issue, the second an backporting the functionality from rl 7 to the extension module.
