### PR TITLE
3.x: don’t include editline/readline.h, use the embedded readline

### DIFF
--- a/Modules/3.x/readline.c
+++ b/Modules/3.x/readline.c
@@ -28,14 +28,10 @@
 #  define RESTORE_LOCALE(sl)
 #endif
 
-#ifdef WITH_EDITLINE
-#  include <editline/readline.h>
-#else
 /* GNU readline definitions */
-#  undef HAVE_CONFIG_H /* Else readline/chardefs.h includes strings.h */
-#  include <readline/readline.h>
-#  include <readline/history.h>
-#endif
+#undef HAVE_CONFIG_H /* Else readline/chardefs.h includes strings.h */
+#include <readline/readline.h>
+#include <readline/history.h>
 
 #ifdef HAVE_RL_COMPLETION_MATCHES
 #define completion_matches(x, y) \


### PR DESCRIPTION
When building for a Python whose own readline module has been configured to use editline, `WITH_EDITLINE` will be defined during the python-gnureadline build, by virtue of its inclusion of "pyconfig.h" (via "Python.h"). This macro being defined caused python-gnureadline to a problem because python-gnureadline is expecting and has configured itself to use its own embedded copy of GNU readline.

This removes the `HAVE_EDITLINE` branch to allow the expected readline headers to be included.

See https://trac.macports.org/ticket/68265.