### PR TITLE
Enable build for Python 3.12 on macOS

### DIFF
--- a/Modules/3.x/readline.c
+++ b/Modules/3.x/readline.c
@@ -28,7 +28,8 @@
 #  define RESTORE_LOCALE(sl)
 #endif
 
-#ifdef WITH_EDITLINE
+/* Exclude on macOS as missing declaration of append_history */
+#if defined(WITH_EDITLINE) && !defined(__APPLE__)
 #  include <editline/readline.h>
 #else
 /* GNU readline definitions */

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from distutils.command.build_ext import build_ext
+from setuptools.command.build_ext import build_ext
 import subprocess
 
 from setuptools import setup, Extension


### PR DESCRIPTION
Replace deprecated package distutils and always use the GNU readline definitions when building on macOS.

System:
MacBook Pro M1
macOS Sonoma 14.2.1
Xcode 15.1 (Apple clang version 15.0.0 (clang-1500.1.0.2.5)

- May solve: https://github.com/ludwigschwardt/python-gnureadline/issues/65