### PR TITLE
Support built-in readlines in override script

### DIFF
--- a/override_readline.py
+++ b/override_readline.py
@@ -71,7 +71,8 @@ def check_module(module_name):
         print("Module {name}: not found".format(name=module_name))
         return None
     style = "libedit" if "libedit" in module.__doc__ else "GNU readline"
-    kwargs = dict(name=module_name, style=style, path=module.__file__)
+    path = getattr(module, "__file__", "(built-in)")
+    kwargs = dict(name=module_name, style=style, path=path)
     print("Module {name}: based on {style}, {path}".format(**kwargs))
     return module
 


### PR DESCRIPTION
The [python-build-standalone](https://gregoryszorc.com/docs/python-build-standalone/main/index.html) Python distribution (used by e.g. [mise](https://mise.jdx.dev/)) compiles the readline module into libpython as a built-in module, instead of the usual extension in the lib-dynload directory.

This means that the `module.__file__` attribute does not exist. Check for this and report a fallback string instead of crashing.

This fixes #74.