### PR TITLE
Update docs to mention Python 3.13 changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,12 @@ If you are using Windows, which also ships without GNU Readline, you might
 want to consider using the `pyreadline3`_ module instead, which is a readline
 replacement written in pure Python that interacts with the Windows clipboard.
 
+**Please note that Python 3.13 introduced a new interactive interpreter.**
+It reimplements some of the GNU Readline functionality in Python and thereby
+bypasses it (for example when entering Ctrl-R to search the command history).
+Its behaviour may be subtly different though. If you want to revert to the
+old interpreter, set the environment variable `PYTHON_BASIC_REPL=1`.
+
 .. _GNU Readline: http://www.gnu.org/software/readline/
 .. _Editline: http://www.thrysoee.dk/editline/
 .. _site: https://docs.python.org/library/site.html


### PR DESCRIPTION
Python 3.13 pretty much does its own thing in the new interpreter, replacing major GNU Readline functionality with Python functions. The behaviour may differ though, so mention how the old interpreter can be restored.

Thanks @milosivanovic for pointing this out! I hadn't realised how much things have changed. This package might soon be obsolete again 😛 